### PR TITLE
Polish C.I. build name so it fits in output

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run clippy
         run: cargo clippy-amaru
   build:
-    name: Build on ${{ matrix.environments.runner }} with target ${{ matrix.environments.target }}
+    name: Build for ${{ matrix.environments.target }} on ${{ matrix.environments.runner }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
GitHub C.I. will cut _long_ build names. So the build with name `Build on ubuntu-latest with target aarch64-unknown-linux-musl` will show in the interface as
`Build on ubuntu-latest with t`. This make it harder to read the C.I. as almost all the builds appear to have the exact same prefix.

By switching the target and the host in the name of the build, the name becomes
`Build for aarch64-unknown-linux-musl on ubuntu-latest`. The prefix is then different for every build.

Not perfect but easier to navigate in the GitHub C.I. interface.